### PR TITLE
Remove limit on last ‘Main’ block WFB layout

### DIFF
--- a/packages/common/components/layouts/wfb-daily.marko
+++ b/packages/common/components/layouts/wfb-daily.marko
@@ -103,7 +103,6 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           continue-reading=true
           with-teaser=true
           url-params=urlParams
-          limit=2
           skip=4
         />
 


### PR DESCRIPTION
allows for unlimited articles scheduled to this section