### PR TITLE
Move each logo inside its own <td> tag

### DIFF
--- a/packages/common/components/blocks/content/partners-ab.marko
+++ b/packages/common/components/blocks/content/partners-ab.marko
@@ -27,28 +27,30 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/ab/premium-partners/Matrix.png'
             options={ w: 120, h: 50, fit: "clip" }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.matrixfitness.com/us/eng' target='_blank' />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/ab/premium-partners/PaddockLogo_Crop.png'
             options={ w: 120, h: 50, fit: "clip" }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.paddockindustries.com/' target='_blank' />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/ab/premium-partners/FORMETCO_SPORTS_LOGO.png'
             options={ w: 120, h: 50, fit: "clip" }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.formetco.com/' target='_blank' />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/ab/premium-partners/MONDO.png'
             options={ w: 120, h: 50, fit: "clip" }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.mondoworldwide.com/na/en/' target='_blank' />
           </marko-newsletter-imgix>
@@ -60,7 +62,6 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/ab/premium-partners/SpectrumAquatics_Logo.png'
             options={ w: 120, h: 50, fit: "clip" }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.spectrumproducts.com/' target='_blank' />
           </marko-newsletter-imgix>

--- a/packages/common/components/blocks/content/partners-aqua.marko
+++ b/packages/common/components/blocks/content/partners-aqua.marko
@@ -21,34 +21,36 @@ $ const urlParams = defaultValue(input.urlParams, false);
 </tr>
 <tr>
   <td align="center" valign="top">
-    <table role="presentation" width="610" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
+    <table role="presentation" width="610" border="0" align="center" cellpadding="5" cellspacing="0" class="wrap003">
       <tr>
         <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/Pleatco-Logo.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.pleatco.com/' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/CovCo_Pegasus2017.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://pegasus-products.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/Fluidra_4C.png'
-            options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
+            options={ w: 120, h: 50, fit: "clip" }
           >
             <@link href='https://www.fluidrausa.com/en' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/HaywardWeBuildLogo_2022.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.hayward-pool.com/shop/en/pools' target="_blank" />
           </marko-newsletter-imgix>
@@ -60,28 +62,30 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/Pentair-Logo-4c.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='http://www.pentairpool.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/tara-logo-CMYK300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.tarapools.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/RBcontrols-logo.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='http://www.rbpoolandspa.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/SpeckPumps_300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://usa.speck-pumps.com/' target="_blank" />
           </marko-newsletter-imgix>
@@ -93,28 +97,30 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/LXS-240_Oxone_Logo_300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://lanxess.com/en/Products-and-Solutions/Brands/Oxone/Pool-and-spa' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/LyonFinancialLogo_cmyk300.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.lyonfinancial.net' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/Intermatic_300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.intermatic.com/Catalog/us/Products/Pool-And-Spa' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/HFS_LOGO_FINAL.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.hfsfinancial.net' target="_blank" />
           </marko-newsletter-imgix>
@@ -126,28 +132,30 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/Viking-Capital-horiz_CMYK300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://poolloan.net' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/AquaStar-Logo_cmyk300.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.aquastarpoolproducts.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/Skimmer_Logo_Horz_Blue.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://getskimmer.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/FROG.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.frogproducts.com/' target="_blank" />
           </marko-newsletter-imgix>
@@ -159,28 +167,30 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/SRSmith_logo.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.srsmith.com/en-us/' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/PoolsideTech_blue_logo.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://poolside.tech/' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/Podium_Logo_300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.podium.com/' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/aqua/premium-partners/HASA_300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://hasapool.com/' target="_blank" />
           </marko-newsletter-imgix>

--- a/packages/common/components/blocks/content/partners-wfb.marko
+++ b/packages/common/components/blocks/content/partners-wfb.marko
@@ -27,28 +27,30 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/Bona_300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://wfbmag.co/BonaPPLogo' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/Stauf.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='http://staufusa.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/Norton_LOGO.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.nortonabrasives.com/en-us/markets/floor-sanding?utm_source=Wood%20Floor%20Business' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/saroyan.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://wfbmag.co/SaroyanHdwds' target="_blank" />
           </marko-newsletter-imgix>
@@ -60,28 +62,30 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/woodwiselogocolor.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='http://www.woodwise.com/' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/Lagler_2x2_300dpi.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://wfbmag.co/laglerlogo' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='files/base/abmedia/all/image/static/wfb/premium-partners/PoloPlaz.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://www.poloplaz.com' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/HFP-Logo_color.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://wfbmag.co/32b8kDY' target="_blank" />
           </marko-newsletter-imgix>
@@ -93,14 +97,14 @@ $ const urlParams = defaultValue(input.urlParams, false);
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/AmericanSandersLogo.png'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://wfbmag.co/3oWX33V' target="_blank" />
           </marko-newsletter-imgix>
+        </td>
+        <td>
           <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/wfb/premium-partners/Bostik-logo.jpg'
             options={ w: 120, h: 50, fit: 'fill', fill: 'solid', 'fill-color': '#ffffff' }
-            attrs={ style: 'padding-right: 15px; padding-left: 15px;' }
           >
             <@link href='https://wfbmag.co/PPlogo' target="_blank" />
           </marko-newsletter-imgix>


### PR DESCRIPTION
This will prevent Outlook from stripping the padding previously applied
BEFORE:
<img width="913" alt="Screen Shot 2022-09-13 at 8 19 39 AM" src="https://user-images.githubusercontent.com/64623209/189912242-7bd60b07-02ee-4869-96ce-f6d1bcda9dba.png">
AFTER:
<img width="1117" alt="Screen Shot 2022-09-13 at 8 19 07 AM" src="https://user-images.githubusercontent.com/64623209/189912232-00814f00-ea19-470b-ada6-cf03e3adf4d2.png">