### PR TITLE
Ab 'community news' header changes

### DIFF
--- a/packages/common/components/blocks/content/list.marko
+++ b/packages/common/components/blocks/content/list.marko
@@ -23,9 +23,13 @@ $ const queryParams = {
 
 <marko-web-query|{ nodes }| name="newsletter-scheduled-content" collapsible=false params=queryParams>
   <if(nodes.length)>
-    <if(withHeader)>
-      <common-list-header-element title=sectionName />
+    <if(sectionName === 'Most Read')>
+      $ const title = date.isoWeekday() === 1 ? 'Friday’s Most Read' : 'Yesterday’s Most Read';
+      <common-list-header-element title=title />
     </if>
+    <else-if(withHeader)>
+      <common-list-header-element title=sectionName />
+    </else-if>
     <for|content| of=nodes>
       <common-content-list-item-block
         content=content

--- a/packages/common/components/layouts/ab-daily.marko
+++ b/packages/common/components/layouts/ab-daily.marko
@@ -132,7 +132,7 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
         <!-- Content list block -->
         <common-content-list-block
           date=date
-          section-name="From the Community: Reader Comments"
+          section-name="Reader Comments"
           newsletter=newsletter
           with-image=false
           with-header=true
@@ -145,7 +145,7 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
 
         <common-content-list-block
           date=date
-          section-name="From the Community: Most Read"
+          section-name="Most Read"
           newsletter=newsletter
           with-header=true
           with-section=false


### PR DESCRIPTION
Monday's Newsletter:
<img width="771" alt="Screen Shot 2022-09-15 at 8 22 31 AM" src="https://user-images.githubusercontent.com/64623209/190415294-980d1aad-de24-4410-83d3-d5b1f8d80bf2.png">
All other day's Newsletter:
<img width="787" alt="Screen Shot 2022-09-15 at 8 22 39 AM" src="https://user-images.githubusercontent.com/64623209/190415390-7637bda8-3f33-410e-baf4-99f5357783ef.png">
