### PR TITLE
Add grey line breaks around first ad on AQUA

### DIFF
--- a/packages/common/components/blocks/ad/emailx.marko
+++ b/packages/common/components/blocks/ad/emailx.marko
@@ -65,7 +65,7 @@ $ const classNames = [`email-x-${alias}-${name}`, input.class];
               </if>
             </td>
           </tr>
-          <common-table-spacer-element height="25" />
+          <common-table-spacer-element height="8" />
         </table>
       </td>
     </tr>

--- a/packages/common/components/layouts/aqua-daily.marko
+++ b/packages/common/components/layouts/aqua-daily.marko
@@ -40,11 +40,14 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
         />
 
         <!-- Sponsored Ad -->
+        <common-table-hr-element />
         <common-ad-wrapper-block
           date=date
           newsletter=newsletter
           ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
         />
+        <common-table-hr-element />
+        <common-table-spacer-element height=15 />
 
         <!-- Content list block (no image)-->
         <common-content-list-block


### PR DESCRIPTION
<img width="767" alt="Screen Shot 2022-09-15 at 10 32 20 AM" src="https://user-images.githubusercontent.com/64623209/190445998-9908e399-79f8-402a-99f5-c8b2ddd67fbe.png">
