### PR TITLE
Remove h: from ‘Facility of Merit’ block logo

### DIFF
--- a/packages/common/components/blocks/content/facility-merit.marko
+++ b/packages/common/components/blocks/content/facility-merit.marko
@@ -60,7 +60,7 @@ $ const sponsoredTagStyle = {
             <marko-newsletter-imgix
               src=advertiser.image.src
               alt=advertiser.image.alt
-              options={ w: 120, h: 50, fit: "crop", auto: "format,compress" }
+              options={ w: 120, fit: "crop", auto: "format,compress" }
               attrs={ border: 0, style: imgStyles }
             >
               <@link href=advertiser.website target="_blank" attrs={ style: imgLinkStyles } />


### PR DESCRIPTION
<img width="870" alt="Screen Shot 2022-09-15 at 2 46 46 PM" src="https://user-images.githubusercontent.com/64623209/190495524-22b442dd-5d60-4811-b2eb-384e9be71867.png">
