### PR TITLE
Fix image styling

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -167,7 +167,7 @@ $ const sponsoredTagStyle = {
                     <marko-newsletter-imgix
                       src=image.src
                       alt=image.alt
-                      options={ w: 400, h: 266, fit: 'clamp' }
+                      options={ w: 400, h: 266, fit: "fill" }
                       class="img_resize2"
                       attrs={ border: 0, width: 200, height: 133, style: imgStyles }
                     >


### PR DESCRIPTION
Current:
<img width="702" alt="Screen Shot 2022-09-23 at 10 23 56 AM" src="https://user-images.githubusercontent.com/64623209/191996406-d536a7e0-aad6-42b9-a52a-197e7f80db1e.png">

Change:
<img width="774" alt="Screen Shot 2022-09-23 at 10 16 59 AM" src="https://user-images.githubusercontent.com/64623209/191996280-5f5372c9-eba2-4014-925e-d6fe0383129e.png">
