### PR TITLE
Remove ‘crop’ & ‘compress’ styling on nativeX logo

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -61,7 +61,7 @@ $ const sponsoredTagStyle = {
               <marko-newsletter-imgix
                 src=advertiser.image.src
                 alt=advertiser.image.alt
-                options={ w: 120, h: 50, fit: "crop", auto: "format,compress" }
+                options={ w: 120, h: 50 }
                 attrs={ border: 0, style: imgStyles }
               >
                 <@link href=advertiser.website target="_blank" attrs={ style: imgLinkStyles } />


### PR DESCRIPTION
<img width="723" alt="Screen Shot 2022-10-31 at 8 50 31 AM" src="https://user-images.githubusercontent.com/64623209/199023641-906a9128-de17-4502-8b5e-341db5cd56b7.png">
