### PR TITLE
Change out ‘Spectrum’ w/ ‘Colorado Time’ premium partner logos

### DIFF
--- a/packages/common/components/blocks/content/partners-ab.marko
+++ b/packages/common/components/blocks/content/partners-ab.marko
@@ -60,11 +60,17 @@ $ const urlParams = defaultValue(input.urlParams, false);
       <tr>
         <td>
           <marko-newsletter-imgix
+            src='/files/base/abmedia/all/image/static/ab/premium-partners/ColoradoTime_logo.png'
+            options={ w: 120, h: 50, fit: "clip" }
+          >
+            <@link href='https://www.coloradotime.com' target='_blank' />
+          </marko-newsletter-imgix>
+          <!-- <marko-newsletter-imgix
             src='/files/base/abmedia/all/image/static/ab/premium-partners/SpectrumAquatics_Logo.png'
             options={ w: 120, h: 50, fit: "clip" }
           >
             <@link href='https://www.spectrumproducts.com/' target='_blank' />
-          </marko-newsletter-imgix>
+          </marko-newsletter-imgix> -->
         </td>
       </tr>
     </table>


### PR DESCRIPTION
Code is commented out because it will alter monthly:
<img width="729" alt="Screen Shot 2022-11-01 at 8 30 29 AM" src="https://user-images.githubusercontent.com/64623209/199245313-20e47838-88cf-4e77-9f80-02130c320225.png">
