### PR TITLE
Adjust height and width of ‘hero’ image & remove extra styling

### DIFF
--- a/packages/common/components/blocks/content/list-item.marko
+++ b/packages/common/components/blocks/content/list-item.marko
@@ -19,11 +19,6 @@ $ const newsletterConfig = config.get(newsletter.alias);
 $ const primaryColor = defaultValue(get(newsletterConfig, "primaryColor"), "#103A57");
 
 $ const imgStyles = {
-  "border": 0,
-  "outline": "none",
-  "text-decoration": "none",
-  "display": "block",
-  "height": "auto !important",
   "max-width": "100% !important",
 };
 
@@ -91,9 +86,9 @@ $ const logoStyle = {
               <marko-newsletter-imgix
                 src=image.src
                 alt=image.alt
-                options={ w: 1220, h: 610, fit: "crop", auto: "format,compress" }
+                options={ w: 610, h: 343, fit: "crop", auto: "format,compress" }
                 class="img_resize1"
-                attrs={ border: 0, width: 610, align: "center", vspace: 5, style: imgStyles }
+                attrs={ border: 0, width: 610, height: 343, align: "center", style: imgStyles }
               >
                 <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles } />
               </marko-newsletter-imgix>


### PR DESCRIPTION
<img width="807" alt="Screen Shot 2022-12-19 at 1 24 50 PM" src="https://user-images.githubusercontent.com/64623209/208504267-f97dde58-a8d2-4940-9e6c-49089ca31b9f.png">
