### PR TITLE
Add ‘with-teaser’ to AQUA product section

### DIFF
--- a/packages/common/components/layouts/aqua-daily.marko
+++ b/packages/common/components/layouts/aqua-daily.marko
@@ -237,6 +237,7 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           with-image=true
           image-position='right'
           with-header=true
+          with-teaser=true
           limit=3
         />
 


### PR DESCRIPTION
<img width="725" alt="Screen Shot 2023-01-05 at 8 06 14 AM" src="https://user-images.githubusercontent.com/64623209/210799148-33db9786-f817-4ada-98df-a15e1e999a16.png">
