### PR TITLE
Swap out AB premium partner logos

### DIFF
--- a/packages/common/components/blocks/content/partners-ab.marko
+++ b/packages/common/components/blocks/content/partners-ab.marko
@@ -58,22 +58,22 @@ $ const urlParams = defaultValue(input.urlParams, false);
       </tr>
       <common-table-spacer-element height=20 />
       <tr>
-        <!-- <td>
+        <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/ab/premium-partners/Spectrum_Logo_2023.png"
             options={ w: 120, h: 50, fit: "clip" }
           >
             <@link href="https://www.spectrumproducts.com/" target="_blank" />
           </marko-newsletter-imgix>
-        </td> -->
-        <td>
+        </td>
+        <!-- <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/ab/premium-partners/ColoradoTime_logo.png"
             options={ w: 120, h: 50, fit: "clip" }
           >
             <@link href="https://www.coloradotime.com" target="_blank" />
           </marko-newsletter-imgix>
-        </td>
+        </td> -->
       </tr>
     </table>
   </td>


### PR DESCRIPTION
<img width="747" alt="Screen Shot 2023-06-01 at 7 35 01 AM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/fb4d3082-1d89-428d-91ef-366748f582bc">
