### PR TITLE
Remove ‘view online’ component

### DIFF
--- a/packages/common/components/blocks/body-wrapper.marko
+++ b/packages/common/components/blocks/body-wrapper.marko
@@ -8,14 +8,6 @@ $ const { newsletter, date } = input;
           <td align="center" valign="top">
             <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
 
-              <!-- View online block -->
-              <if(input.viewOnline)>
-                <${input.viewOnline} />
-              </if>
-              <else>
-                <common-view-online-block />
-              </else>
-
               <!-- Header block -->
               <if(input.header)>
                 <${input.header} />


### PR DESCRIPTION
<img width="871" alt="Screen Shot 2023-08-31 at 2 53 10 PM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/b81ebe75-2e29-4d5d-ab7a-631d3685b73d">
<img width="675" alt="Screen Shot 2023-08-31 at 2 53 15 PM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/f86edac9-5985-47d4-9830-5e0acc980054">
<img width="782" alt="Screen Shot 2023-08-31 at 2 53 22 PM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/0de70a93-9b51-4ab2-ae69-c0c17c2a4555">
