### PR TITLE
Remove ‘Hayward’ & ‘SpeckPumps’ from Aqua’s Premium Partners

### DIFF
--- a/packages/common/components/blocks/content/partners-aqua.marko
+++ b/packages/common/components/blocks/content/partners-aqua.marko
@@ -49,23 +49,15 @@ $ const urlParams = defaultValue(input.urlParams, false);
         </td>
         <td>
           <marko-newsletter-imgix
-            src="/files/base/abmedia/all/image/static/aqua/premium-partners/HaywardWeBuildLogo_2022.png"
-            options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
-          >
-            <@link href="https://www.hayward-pool.com/shop/en/pools" target="_blank" />
-          </marko-newsletter-imgix>
-        </td>
-      </tr>
-      <common-table-spacer-element height="10" />
-      <tr>
-        <td>
-          <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/Pentair-Logo-4c.png"
             options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
           >
             <@link href="http://www.pentairpool.com" target="_blank" />
           </marko-newsletter-imgix>
         </td>
+      </tr>
+      <common-table-spacer-element height="10" />
+      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/tara-logo-CMYK300dpi.png"
@@ -84,17 +76,6 @@ $ const urlParams = defaultValue(input.urlParams, false);
         </td>
         <td>
           <marko-newsletter-imgix
-            src="/files/base/abmedia/all/image/static/aqua/premium-partners/SpeckPumps_300dpi.png"
-            options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
-          >
-            <@link href="https://usa.speck-pumps.com/" target="_blank" />
-          </marko-newsletter-imgix>
-        </td>
-      </tr>
-      <common-table-spacer-element height="10" />
-      <tr>
-        <td>
-          <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/LXS-240_Oxone_Logo_300dpi.png"
             options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
           >
@@ -109,6 +90,9 @@ $ const urlParams = defaultValue(input.urlParams, false);
             <@link href="https://www.lyonfinancial.net" target="_blank" />
           </marko-newsletter-imgix>
         </td>
+      </tr>
+      <common-table-spacer-element height="10" />
+      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/Intermatic_300dpi.png"
@@ -125,9 +109,6 @@ $ const urlParams = defaultValue(input.urlParams, false);
             <@link href="https://www.hfsfinancial.net" target="_blank" />
           </marko-newsletter-imgix>
         </td>
-      </tr>
-      <common-table-spacer-element height="10" />
-      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/Viking-Capital-horiz_CMYK300dpi.png"
@@ -144,6 +125,9 @@ $ const urlParams = defaultValue(input.urlParams, false);
             <@link href="https://www.aquastarpoolproducts.com" target="_blank" />
           </marko-newsletter-imgix>
         </td>
+      </tr>
+      <common-table-spacer-element height="10" />
+      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/FROG.png"
@@ -160,9 +144,6 @@ $ const urlParams = defaultValue(input.urlParams, false);
             <@link href="https://poolside.tech/" target="_blank" />
           </marko-newsletter-imgix>
         </td>
-      </tr>
-      <common-table-spacer-element height="10" />
-      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/HASA_300dpi.png"
@@ -179,6 +160,9 @@ $ const urlParams = defaultValue(input.urlParams, false);
             <@link href="https://bluetorrentpoolproducts.com/" target="_blank" />
           </marko-newsletter-imgix>
         </td>
+      </tr>
+      <common-table-spacer-element height="10" />
+      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/biolab-only-logo.png"
@@ -195,9 +179,6 @@ $ const urlParams = defaultValue(input.urlParams, false);
             <@link href="https://www.celtichottubs.com/" target="_blank" />
           </marko-newsletter-imgix>
         </td>
-      </tr>
-      <common-table-spacer-element height="10" />
-      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/HPSG-Primary-Logo.png"


### PR DESCRIPTION
<img width="565" alt="Screen Shot 2023-11-08 at 1 42 57 PM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/92d4afe5-629c-45a2-bcf4-bafa61afac4b">
