### PR TITLE
Flip AB partner to Spectrum for Jan

### DIFF
--- a/packages/common/components/blocks/content/partners-ab.marko
+++ b/packages/common/components/blocks/content/partners-ab.marko
@@ -58,22 +58,22 @@ $ const urlParams = defaultValue(input.urlParams, false);
       </tr>
       <common-table-spacer-element height=20 />
       <tr>
-        <!-- <td>
+        <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/ab/premium-partners/Spectrum_Logo_2023.png"
             options={ w: 120, h: 50, fit: "clip" }
           >
             <@link href="https://www.spectrumproducts.com/" target="_blank" />
           </marko-newsletter-imgix>
-        </td> -->
-        <td>
+        </td>
+        <!-- <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/ab/premium-partners/ColoradoTime_logo.png"
             options={ w: 120, h: 50, fit: "clip" }
           >
             <@link href="https://www.coloradotime.com" target="_blank" />
           </marko-newsletter-imgix>
-        </td>
+        </td> -->
       </tr>
     </table>
   </td>


### PR DESCRIPTION
**Can be merged 'early' since they aren't sending a newsletter out til Jan 2**


<img width="804" alt="Screen Shot 2023-12-28 at 3 01 52 PM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/9b0932ca-b444-4cbe-bf32-3573e07104ed">
