### PR TITLE
Remove Blue Torrent from AQUA premium partner

### DIFF
--- a/packages/common/components/blocks/content/partners-aqua.marko
+++ b/packages/common/components/blocks/content/partners-aqua.marko
@@ -154,23 +154,15 @@ $ const urlParams = defaultValue(input.urlParams, false);
         </td>
         <td>
           <marko-newsletter-imgix
-            src="/files/base/abmedia/all/image/static/aqua/premium-partners/BlueTorrent_300cmyk.psd"
-            options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
-          >
-            <@link href="https://bluetorrentpoolproducts.com/" target="_blank" />
-          </marko-newsletter-imgix>
-        </td>
-      </tr>
-      <common-table-spacer-element height="10" />
-      <tr>
-        <td>
-          <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/biolab-only-logo.png"
             options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
           >
             <@link href="https://www.kikcorp.com/our-products/#pool-care" target="_blank" />
           </marko-newsletter-imgix>
         </td>
+      </tr>
+      <common-table-spacer-element height="10" />
+      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/celtic-hottubs-logo.png"


### PR DESCRIPTION
<img width="693" alt="Screen Shot 2024-01-15 at 10 03 56 AM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/ed4bc354-2d2b-4169-804c-0b45f614af2c">
