### PR TITLE
Update AB layout to match Aqua layout (ad spots) and create 'Daily Dig' section/ad 

### DIFF
--- a/packages/common/components/blocks/ad/marko.json
+++ b/packages/common/components/blocks/ad/marko.json
@@ -19,5 +19,8 @@
   },
   "<common-ad-promotion-ab-block>": {
     "template": "./promotion-ab.marko"
+  },
+  "<common-ad-promotion-daily-dig-block>": {
+    "template": "./promotion-daily-dig.marko"
   }
 }

--- a/packages/common/components/blocks/ad/promotion-daily-dig.marko
+++ b/packages/common/components/blocks/ad/promotion-daily-dig.marko
@@ -1,8 +1,6 @@
-import { get, getAsObject } from "@parameter1/base-cms-object-path";
+import { getAsObject } from "@parameter1/base-cms-object-path";
 
 $ const newsletter = getAsObject(input, "newsletter");
-$ const { sectionName, date, content, advertiser } = input;
+$ const { content, advertiser } = input;
 
-$ content.labels = ["Sponsored"];
-
-<common-content-daily-dig-block newsletter=newsletter content=content withImage=true advertiser=advertiser />
+<common-content-daily-dig-block newsletter=newsletter content=content advertiser=advertiser />

--- a/packages/common/components/blocks/ad/promotion-daily-dig.marko
+++ b/packages/common/components/blocks/ad/promotion-daily-dig.marko
@@ -1,0 +1,8 @@
+import { get, getAsObject } from "@parameter1/base-cms-object-path";
+
+$ const newsletter = getAsObject(input, "newsletter");
+$ const { sectionName, date, content, advertiser } = input;
+
+$ content.labels = ["Sponsored"];
+
+<common-content-daily-dig-block newsletter=newsletter content=content withImage=true advertiser=advertiser />

--- a/packages/common/components/blocks/ad/wrapper.marko
+++ b/packages/common/components/blocks/ad/wrapper.marko
@@ -6,6 +6,7 @@ import PromotionNativeBlock from "./promotion-native";
 import PromotionSponsoredBlock from "./promotion-sponsored";
 import PromotionAquaBlock from "./promotion-aqua";
 import PromotionAbBlock from "./promotion-ab";
+import PromotionDailyDig from "./promotion-daily-dig";
 
 $ const { config } = out.global;
 $ const nativeX = config.getAsObject("nativeX");
@@ -20,6 +21,7 @@ $ const promotionComponents = {
   "sponsored-block": PromotionSponsoredBlock,
   "aqua-block": PromotionAquaBlock,
   "ab-block": PromotionAbBlock,
+  "daily-dig-block": PromotionDailyDig
 };
 $ const PromotionComponent = promotionComponents[defaultValue(input.promotionComponent, "advertisement-block")];
 

--- a/packages/common/components/blocks/content/daily-dig.marko
+++ b/packages/common/components/blocks/content/daily-dig.marko
@@ -1,0 +1,116 @@
+import { get, getAsArray } from "@parameter1/base-cms-object-path";
+import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
+import { URLSearchParams } from "url";
+
+$ const { config } = out.global;
+
+$ const { newsletter, content, urlParams, advertiser } = input;
+
+$ const withImage = defaultValue(input.withImage, false);
+$ const imagePosition = defaultValue(input.imagePosition, 'right');
+$ const withSection = defaultValue(input.withSection, true);
+$ const continueReading = defaultValue(input.continueReading, false);
+$ const withTeaser = defaultValue(input.withTeaser, true);
+
+$ const queryString = (urlParams && content.type !== 'promotion') ? `?${new URLSearchParams(urlParams)}` : "";
+$ const contentUrl = `${content.siteContext.url}${queryString}`
+
+$ const newsletterConfig = config.get(newsletter.alias);
+$ const primaryColor = defaultValue(get(newsletterConfig, "primaryColor"), "#103A57");
+
+$ const imgStyles = {
+  "border": 0,
+  "outline": "none",
+  "text-decoration": "none",
+  "display": "block",
+  "height": "auto !important",
+  "max-width": "100% !important",
+};
+
+$ const imgLinkStyles = {
+  "border": 0,
+  "outline": "none",
+  "text-decoration": "none",
+};
+
+$ const tagStyle = {
+  "font-size": "14px",
+  "font-weight": "700",
+  "line-height": "19px",
+}
+
+<tr>
+  <td align="center" valign="top">
+    <table role="presentation" width="610" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
+      <tr>
+        <td align="center" valign="top">
+          <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
+            <marko-newsletter-imgix
+              src=image.src
+              alt=image.alt
+              options={ w: 600, h: 200, auto: "format,compress" }
+              class="img_resize1"
+              attrs={ border: 0, width: 600, height: 200, align: "center" }
+            >
+              <@link href=contentUrl target="_blank" attrs={ style: imgLinkStyles } />
+            </marko-newsletter-imgix>
+          </marko-core-obj-value>
+        </td>
+      </tr>
+    </table>
+    <table align="right">
+      $ const labels = getAsArray(content, "labels");
+      $ const tag = (content.company) ? `Powered by` : "Sponsored Content";
+      <tr>
+        <td align="right" valign="center" style=tagStyle>${tag}</td>
+        <td align="right">
+          <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
+            <marko-newsletter-imgix
+              src=advertiser.image.src
+              alt=advertiser.image.alt
+              options={ w: 120, fit: "crop", auto: "format,compress" }
+              attrs={ border: 0, style: imgStyles }
+            >
+              <@link href=advertiser.website target="_blank" attrs={ style: imgLinkStyles } />
+            </marko-newsletter-imgix>
+          </marko-core-obj-value>
+        </td>
+      </tr>
+    </table>
+    <table role="presentation" width="610" border="0" align="center" cellpadding="0" cellspacing="0" class="wrap003">
+      <common-table-spacer-element height="10" />
+      <tr>
+        <td align="left" valign="top">
+          <table role="presentation" width="100%" border="0" cellpadding="0" cellspacing="0" class="pad" style="padding: 0 30px 0px 0;">
+            <tr>
+              <td align="left" valign="top">
+                <a style="font-size: 24px;line-height: 28px;color: #202022;font-weight: 700;text-decoration: none;" class="font1" target="_blank" href=contentUrl>
+                  ${content.name}
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td>
+                <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
+                  <common-table-spacer-element height="5" />
+                  <if(withTeaser)>
+                    <tr>
+                      <td align="left" valign="top" style="font-size: 17px;line-height: 23px;color: #202022;font-weight: 400;">
+                        ${content.teaser}
+                      </td>
+                    </tr>
+                  </if>
+                  <if(continueReading)>
+                    <common-table-spacer-element height="9" />
+                    <common-cta-element link-url=contentUrl />
+                  </if>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+      <common-table-spacer-element height="32" />
+    </table>
+  </td>
+</tr>

--- a/packages/common/components/blocks/content/daily-dig.marko
+++ b/packages/common/components/blocks/content/daily-dig.marko
@@ -1,4 +1,4 @@
-import { get, getAsArray } from "@parameter1/base-cms-object-path";
+import { get } from "@parameter1/base-cms-object-path";
 import defaultValue from "@parameter1/base-cms-marko-core/utils/default-value";
 import { URLSearchParams } from "url";
 
@@ -14,9 +14,6 @@ $ const withTeaser = defaultValue(input.withTeaser, true);
 
 $ const queryString = (urlParams && content.type !== 'promotion') ? `?${new URLSearchParams(urlParams)}` : "";
 $ const contentUrl = `${content.siteContext.url}${queryString}`
-
-$ const newsletterConfig = config.get(newsletter.alias);
-$ const primaryColor = defaultValue(get(newsletterConfig, "primaryColor"), "#103A57");
 
 $ const imgStyles = {
   "border": 0,
@@ -59,7 +56,6 @@ $ const tagStyle = {
       </tr>
     </table>
     <table align="right">
-      $ const labels = getAsArray(content, "labels");
       $ const tag = (content.company) ? `Powered by` : "Sponsored Content";
       <tr>
         <td align="right" valign="center" style=tagStyle>${tag}</td>

--- a/packages/common/components/blocks/content/marko.json
+++ b/packages/common/components/blocks/content/marko.json
@@ -34,5 +34,8 @@
   },
   "<common-content-facility-merit-block>": {
     "template": "./facility-merit.marko"
+  },
+  "<common-content-daily-dig-block>": {
+    "template": "./daily-dig.marko"
   }
 }

--- a/packages/common/components/layouts/ab-daily.marko
+++ b/packages/common/components/layouts/ab-daily.marko
@@ -54,14 +54,43 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           skip=0
         />
 
-        <!-- Advertisement / Promotional by block-->
-        <common-ad-wrapper-block
-          date=date
-          newsletter=newsletter
-          promotion-component="advertisement-block"
-          ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
-          placement-id=get(nativeX, `placements.${newsletter.alias}.slot-1`)
-        />
+        <!-- Split Sponsored block-->
+        <common-table-hr-element />
+        <common-table-spacer-element height="12" />
+        <tr>
+          <td>
+            <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+              <tr>
+                <td align="center" valign="middle" style="font-size:15px;line-height:20px; color:#666666;font-weight:400;text-align: center;">Sponsored</td>
+              </tr>
+              <common-table-spacer-element height="12" />
+            </table>
+            <table align="left" role="presentation" width="300" border="0" cellpadding="0" cellspacing="0">
+              <tr>
+                <td>
+                  <common-ad-promotion-sponsored-block
+                    date=date
+                    newsletter=newsletter
+                    ad-unit=emailX.getAdUnit({ name: "ad-slot-1", alias: newsletter.alias })
+                  />
+                </td>
+              </tr>
+            </table>
+            <table align="right" role="presentation" width="300" border="0" cellpadding="0" cellspacing="0">
+              <tr>
+                <td>
+                  <common-ad-promotion-sponsored-block
+                    date=date
+                    newsletter=newsletter
+                    ad-unit=emailX.getAdUnit({ name: "ad-slot-2", alias: newsletter.alias })
+                  />
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <common-table-hr-element />
+        <common-table-spacer-element height="20" />
 
         <!-- Content list block-->
         <common-content-list-block
@@ -86,6 +115,28 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
         <!-- Content list block -->
         <common-content-list-block
           date=date
+          section-name="Daily Digs"
+          newsletter=newsletter
+          with-image=true
+          image-position="right"
+          with-header=false
+          with-section=false
+          with-teaser=true
+          url-params=urlParams
+          limit=1
+        />
+
+        <!--Daily Digs -->
+        <common-ad-wrapper-block
+          date=date
+          newsletter=newsletter
+          promotion-component="daily-dig-block"
+          placement-id=get(nativeX, `placements.${newsletter.alias}.daily-digs`)
+        />
+
+        <!-- Content list block -->
+        <common-content-list-block
+          date=date
           section-name="Main"
           newsletter=newsletter
           with-section=false
@@ -95,14 +146,43 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           skip=2
         />
 
-        <!-- Advertisement / Promotional by block-->
-        <common-ad-wrapper-block
-          date=date
-          newsletter=newsletter
-          promotion-component="advertisement-block"
-          ad-unit=emailX.getAdUnit({ name: "ad-slot-2", alias: newsletter.alias })
-          placement-id=get(nativeX, `placements.${newsletter.alias}.slot-2`)
-        />
+        <!-- Split Sponsored block-->
+        <common-table-hr-element />
+        <common-table-spacer-element height="12" />
+        <tr>
+          <td>
+            <table role="presentation" width="100%" border="0" align="center" cellpadding="0" cellspacing="0">
+              <tr>
+                <td align="center" valign="middle" style="font-size:15px;line-height:20px; color:#666666;font-weight:400;text-align: center;">Sponsored</td>
+              </tr>
+              <common-table-spacer-element height="12" />
+            </table>
+            <table align="left" role="presentation" width="300" border="0" cellpadding="0" cellspacing="0">
+              <tr>
+                <td>
+                  <common-ad-promotion-sponsored-block
+                    date=date
+                    newsletter=newsletter
+                    ad-unit=emailX.getAdUnit({ name: "ad-slot-3", alias: newsletter.alias })
+                  />
+                </td>
+              </tr>
+            </table>
+            <table align="right" role="presentation" width="300" border="0" cellpadding="0" cellspacing="0">
+              <tr>
+                <td>
+                  <common-ad-promotion-sponsored-block
+                    date=date
+                    newsletter=newsletter
+                    ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
+                  />
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <common-table-hr-element />
+        <common-table-spacer-element height="20" />
 
         <!-- Content list block -->
         <common-content-list-block
@@ -121,7 +201,7 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           date=date
           newsletter=newsletter
           promotion-component="advertisement-block"
-          ad-unit=emailX.getAdUnit({ name: "ad-slot-3", alias: newsletter.alias })
+          ad-unit=emailX.getAdUnit({ name: "ad-slot-5", alias: newsletter.alias })
           placement-id=get(nativeX, `placements.${newsletter.alias}.slot-3`)
         />
 
@@ -156,7 +236,6 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           date=date
           newsletter=newsletter
           promotion-component="advertisement-block"
-          ad-unit=emailX.getAdUnit({ name: "ad-slot-4", alias: newsletter.alias })
           placement-id=get(nativeX, `placements.${newsletter.alias}.slot-4`)
         />
 
@@ -175,7 +254,6 @@ $ const urlParams = (utmTerm) ? { "utm_term" : utmTerm } : false;
           date=date
           newsletter=newsletter
           promotion-component="advertisement-block"
-          ad-unit=emailX.getAdUnit({ name: "ad-slot-5", alias: newsletter.alias })
           placement-id=get(nativeX, `placements.${newsletter.alias}.slot-5`)
         />
 

--- a/tenants/all/config/native-x.js
+++ b/tenants/all/config/native-x.js
@@ -7,6 +7,7 @@ module.exports = {
       'facility-of-the-week': '62f3faa65a48b000011fb169',
       'sponsored-content': '6318dd5d646e0b00017c1f6a',
       'facility-of-merit': '631f60c9646e0b00018e4015',
+      'daily-digs': '65b9145353edb10001f39fcc',
       'slot-1': '62b2220b1c9be80001f4e117',
       'slot-2': '62c6c80e4e70600001b24506',
       'slot-3': '62c6c8246b7dcc0001967589',


### PR DESCRIPTION
<img width="801" alt="Screen Shot 2024-01-30 at 10 31 04 AM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/21fdaa66-13eb-43a4-824c-fdaf359a32cc">
<img width="783" alt="Screen Shot 2024-01-30 at 10 31 24 AM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/3dfef0ae-b8d9-4fcc-bea6-123687faf19a">
