### PR TITLE
Remove HASA from Aqua’s premium partner

### DIFF
--- a/packages/common/components/blocks/content/partners-aqua.marko
+++ b/packages/common/components/blocks/content/partners-aqua.marko
@@ -146,23 +146,12 @@ $ const urlParams = defaultValue(input.urlParams, false);
         </td>
         <td>
           <marko-newsletter-imgix
-            src="/files/base/abmedia/all/image/static/aqua/premium-partners/HASA_300dpi.png"
-            options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
-          >
-            <@link href="https://hasapool.com/" target="_blank" />
-          </marko-newsletter-imgix>
-        </td>
-        <td>
-          <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/biolab-only-logo.png"
             options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
           >
             <@link href="https://www.kikcorp.com/our-products/#pool-care" target="_blank" />
           </marko-newsletter-imgix>
         </td>
-      </tr>
-      <common-table-spacer-element height="10" />
-      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/celtic-hottubs-logo.png"
@@ -171,6 +160,9 @@ $ const urlParams = defaultValue(input.urlParams, false);
             <@link href="https://www.celtichottubs.com/" target="_blank" />
           </marko-newsletter-imgix>
         </td>
+      </tr>
+      <common-table-spacer-element height="10" />
+      <tr>
         <td>
           <marko-newsletter-imgix
             src="/files/base/abmedia/all/image/static/aqua/premium-partners/HPSG-Primary-Logo.png"


### PR DESCRIPTION
<img width="717" alt="Screen Shot 2024-02-27 at 8 50 21 AM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/353b1772-1d26-4d89-a70b-76f50828edca">
