### PR TITLE
Upload new Pentair logo (aqua-partner)

### DIFF
--- a/packages/common/components/blocks/content/partners-aqua.marko
+++ b/packages/common/components/blocks/content/partners-aqua.marko
@@ -49,7 +49,7 @@ $ const urlParams = defaultValue(input.urlParams, false);
         </td>
         <td>
           <marko-newsletter-imgix
-            src="/files/base/abmedia/all/image/static/aqua/premium-partners/Pentair-Logo-4c.png"
+            src="/files/base/abmedia/all/image/static/aqua/premium-partners/Pentair-Pool_Primary-Logo_RGB.jpg"
             options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
           >
             <@link href="http://www.pentairpool.com" target="_blank" />


### PR DESCRIPTION
<img width="537" alt="Screenshot 2024-03-22 at 1 02 01 PM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/314cf0b5-8478-4951-b05a-d8e357d7cc98">
