### PR TITLE
Use cropped image for Pentair Pool (aqua premium partner)

### DIFF
--- a/packages/common/components/blocks/content/partners-aqua.marko
+++ b/packages/common/components/blocks/content/partners-aqua.marko
@@ -49,7 +49,7 @@ $ const urlParams = defaultValue(input.urlParams, false);
         </td>
         <td>
           <marko-newsletter-imgix
-            src="/files/base/abmedia/all/image/static/aqua/premium-partners/Pentair-Pool_Primary-Logo_RGB.jpg"
+            src="/files/base/abmedia/all/image/static/aqua/premium-partners/Pentair-Pool_Primary-Logo_RGB_web.jpg"
             options={ w: 120, h: 50, fit: "fill", fill: "solid", "fill-color": "#ffffff" }
           >
             <@link href="http://www.pentairpool.com" target="_blank" />


### PR DESCRIPTION
<img width="827" alt="Screenshot 2024-03-27 at 9 15 39 AM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/6ac224be-def3-4be8-9902-b046c873ecce">
