### PR TITLE
Add padding on NativeX ad image

### DIFF
--- a/packages/common/components/blocks/ad/promotion-advertisement.marko
+++ b/packages/common/components/blocks/ad/promotion-advertisement.marko
@@ -51,7 +51,7 @@ $ const nameLinkAttrs = { style: nameLinkStyles, ...linkAttrs };
         <td align="center" valign="top" dir="rtl">
           <table role="presentation" width="100%" border="0" cellspacing="0" cellpadding="0">
             <tr>
-              <td align="right" valign="top" width="200" class="wdt">
+              <td align="right" valign="top" width="200" class="wdt" style="padding-left:5px;">
                 <marko-core-obj-value|{ value: image }| obj=content field="primaryImage" as="object">
                   <marko-newsletter-imgix
                     src=image.src


### PR DESCRIPTION
<img width="720" alt="Screenshot 2024-04-29 at 7 27 11 AM" src="https://github.com/parameter1/ab-media-newsletters/assets/64623209/37a126d4-7e6f-4d11-8c28-6c9bfd394929">
