### PR TITLE
Remove website-section on Breaking News template

### DIFF
--- a/packages/common/components/layouts/breaking-news.marko
+++ b/packages/common/components/layouts/breaking-news.marko
@@ -38,6 +38,7 @@ $ const nativeX = config.getAsObject("nativeX");
           newsletter=newsletter
           with-image=true
           image-position="top"
+          with-section=false
           limit=1
         />
 


### PR DESCRIPTION
<img width="618" alt="Screenshot 2024-09-30 at 12 00 10 PM" src="https://github.com/user-attachments/assets/39af00e0-e8bf-402f-91ca-7151fe26258c">
